### PR TITLE
Revert "Dockerfile: ignore sonarqube exit code"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -80,7 +80,7 @@ RUN cd .. && if [ ${SONARQUBE} ]; then \
        -Dsonar.github.pullRequest=${TRAVIS_PULL_REQUEST} \
        -Dsonar.github.repository=${TRAVIS_REPO_SLUG} \
        -Dsonar.github.oauth=${SONARQUBE_GITHUB_TOKEN}) \
-    -Dsonar.login=${SONARQUBE_TOKEN} || true; \
+    -Dsonar.login=${SONARQUBE_TOKEN}; \
 fi && cd -
 USER root
 RUN make install


### PR DESCRIPTION
Sonarqube is back to normal.
This reverts commit eded0e1673d765503ab6b324c72eba87ca555c5d.