### PR TITLE
Update to reflect interface changes in FleCSI release/0.1

### DIFF
--- a/flecsi-sp/io/exodus_definition.h
+++ b/flecsi-sp/io/exodus_definition.h
@@ -979,7 +979,7 @@ public:
   /// Return the set of vertices of a particular entity.
   /// \param [in] dimension  The entity dimension to query.
   /// \param [in] entity_id  The id of the entity in question.
-  const auto & entities(size_t from_dim, size_t to_dim) const {
+  connectivity_t entities(size_t from_dim, size_t to_dim) const {
     return entities_.at(from_dim).at(to_dim);
   } // vertices
 
@@ -1327,7 +1327,7 @@ public:
   /// Return the set of vertices of a particular entity.
   /// \param [in] dimension  The entity dimension to query.
   /// \param [in] entity_id  The id of the entity in question.
-  const auto & entities(size_t from_dim, size_t to_dim) const {
+  connectivity_t  entities(size_t from_dim, size_t to_dim) const override {
     return entities_.at(from_dim).at(to_dim);
   } // vertices
 
@@ -1800,7 +1800,7 @@ public:
   /// Return the set of vertices of a particular entity.
   /// \param [in] dimension  The entity dimension to query.
   /// \param [in] entity_id  The id of the entity in question.
-  const auto & entities(size_t from_dim, size_t to_dim) const {
+  connectivity_t entities(size_t from_dim, size_t to_dim) const {
     return entities_.at(from_dim).at(to_dim);
   } // vertices
 

--- a/flecsi-sp/io/x3d_definition.h
+++ b/flecsi-sp/io/x3d_definition.h
@@ -664,7 +664,7 @@ class x3d_definition__<2, T> : public flecsi::topology::mesh_definition_u<2> {
   //! \param [in] from_dim The dimension of the entities for which the
   //! definition is being requested.
   //! \param [in] to_dim The dimension of the entities of the definition.
-  const auto & entities(size_t from_dim, size_t to_dim) const {
+  connectivity_t entities(size_t from_dim, size_t to_dim) const {
     return entities_.at(from_dim).at(to_dim);
   }  // entities
 
@@ -924,7 +924,7 @@ class x3d_definition__<3, T> : public flecsi::topology::mesh_definition_u<3> {
   //! \param [in] from_dim The dimension of the entities for which the
   //! definition is being requested.
   //! \param [in] to_dim The dimension of the entities of the definition.
-  const auto & entities(size_t from_dim, size_t to_dim) const {
+  connectivity_t entities(size_t from_dim, size_t to_dim) const {
     return entities_.at(from_dim).at(to_dim);
   }  // entities
 


### PR DESCRIPTION
This dropped the `const` from some functions used within flecsi-sp.  We should re-evaluate if this should be put back in.  This is related to [PR 553 in FleCSI](https://github.com/laristra/flecsi/pull/553)

@ryosukep 